### PR TITLE
Add command groups for virtual

### DIFF
--- a/src/doc/admin.ad
+++ b/src/doc/admin.ad
@@ -82,6 +82,7 @@ The command groups and their subcommands:
 - **user:     ** add, drop, edit, grant, list, permission, revoke, passwd;
 - **role:     ** add, drop, grant, list, permission, revoke;
 - **db:       ** backup, copy, create, drop, migrate, optimize, list, online, offline, repair, restore, status.
+- **virtual:  ** add, import, list, mappings, options, remove;
 
 The main help command for either CLI tool will print a listing of the
 command groups:


### PR DESCRIPTION
I would have updated the manpage references as well but it looks like they're generated separately from the main stardog-docs and I didn't think you'd want a bunch of broken links.